### PR TITLE
chore: add forms for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,50 @@
+name: "🐛 Bug Report"
+description: "Report a reproducible bug or regression"
+title: "[BUG]"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: synopsis
+    attributes:
+      label: What happened?
+      description: Describe the bug and add steps to reproduce
+      placeholder: |
+        Bug: ...
+        Step 1: ...
+        Step 2: ...
+    validations:
+      required: true
+  - type: textarea
+    id: expectation
+    attributes:
+      label: Expectation?
+      description: What did you expect to happen?
+      placeholder: It should...
+    validations:
+      required: true
+  - type: dropdown
+    id: section
+    attributes:
+      label: Section
+      description: In what part of the project does the bug exists?
+      options:
+        - client
+        - server
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: code
+    attributes:
+      label: Code
+      description: Please copy and paste any relevant code (no need to use backticks)
+      render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please copy and paste any relevant screenshots

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,18 @@
+name: "🚀 Feature Request"
+description: "Submit a proposal/request for a new feature"
+title: "[FEATURE]"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: synopsis
+    attributes:
+      label: What would you like to have added
+      description: Describe the feature request
+      placeholder: |
+        Request: ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-proposal.yml
@@ -1,0 +1,18 @@
+name: "🔨 Refactor"
+description: "Submit a proposal/request for the refactor"
+title: "[REFACTOR]"
+labels: ["refactor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this refactor proposal!
+  - type: textarea
+    id: synopsis
+    attributes:
+      label: What would you like to change
+      description: Describe the refactor request
+      placeholder: |
+        Refactor: ...
+    validations:
+      required: true


### PR DESCRIPTION
## What is this?
When someone want to create an issue, there are 3 options. The user can fill in a form.

## How does it work?

## How to test?

## Checklist
- [ ] Added label